### PR TITLE
Destructuring Macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,6 @@ There are some exercises that are purely in the test namespace:
 
 [kaocha]: https://github.com/lambdaisland/kaocha
 
-[macros]: https://clojure.org/reference/macros
+[macros]: https://www.braveclojure.com/writing-macros/
 
 [tdd-katas]: https://tddmanifesto.com/exercises/

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Each namespace contains a different exploration/exercise:
   [hacker-rank].
 * `tdd` - katas from [TDD Manifesto Katas][tdd-katas].
 * `spec` - my studies on [clojure.spec][clojure.spec].
+* `macros` - learning how [macros][macros] work.
 
 ## Unit Tests
 
@@ -56,14 +57,16 @@ There are some exercises that are purely in the test namespace:
   [destructuring] in test format.
 *
 
-[code-arcade]: https://app.codesignal.com/arcade
-
-[hacker-rank]: https://www.hackerrank.com/
-
-[tdd-katas]: https://tddmanifesto.com/exercises/
-
 [clojure.spec]: https://clojure.org/guides/spec
+
+[code-arcade]: https://app.codesignal.com/arcade
 
 [destructuring]: https://clojure.org/guides/destructuring
 
+[hacker-rank]: https://www.hackerrank.com/
+
 [kaocha]: https://github.com/lambdaisland/kaocha
+
+[macros]: https://clojure.org/reference/macros
+
+[tdd-katas]: https://tddmanifesto.com/exercises/

--- a/src/main/pedromanoel/playground/macros/destructuring.clj
+++ b/src/main/pedromanoel/playground/macros/destructuring.clj
@@ -1,4 +1,5 @@
-(ns pedromanoel.playground.macros.destructuring)
+(ns pedromanoel.playground.macros.destructuring
+  (:require [pedromanoel.playground.macros.destructuring.maps :as maps]))
 
 (defn binding-keys
   "Receives a pair of binding-spec and binding-val:
@@ -12,6 +13,5 @@
        vec))
 
 (defmacro my-let [binding-spec & forms]
-  (apply list
-         'let (binding-keys binding-spec)
+  (apply list 'let (maps/bindings binding-spec)
          forms))

--- a/src/main/pedromanoel/playground/macros/destructuring.clj
+++ b/src/main/pedromanoel/playground/macros/destructuring.clj
@@ -1,1 +1,17 @@
 (ns pedromanoel.playground.macros.destructuring)
+
+(defn binding-keys
+  "Receives a pair of binding-spec and binding-val:
+   Ex.: [x 1], where x is the binding-spec and 1 is the binding-val.
+
+   If the spec is a map "
+  [[binding-spec binding-val]]
+  (->> (:keys binding-spec)
+       (map (juxt identity #((keyword %) binding-val)))
+       (reduce concat)
+       vec))
+
+(defmacro my-let [binding-spec & forms]
+  (apply list
+         'let (binding-keys binding-spec)
+         forms))

--- a/src/main/pedromanoel/playground/macros/destructuring.clj
+++ b/src/main/pedromanoel/playground/macros/destructuring.clj
@@ -1,0 +1,1 @@
+(ns pedromanoel.playground.macros.destructuring)

--- a/src/main/pedromanoel/playground/macros/destructuring/maps.clj
+++ b/src/main/pedromanoel/playground/macros/destructuring/maps.clj
@@ -1,25 +1,31 @@
 (ns pedromanoel.playground.macros.destructuring.maps)
 
-(defn keys-bindings
+(defn keys-spec->bindings
+  "Converts keys into bindings. Ex.: [{:keys [x]} {:x 1}] => [x 1]"
   [binding-val [spec-key spec-val]]
   (when (= :keys spec-key)
     (->> spec-val
              (map (juxt identity (comp (partial get binding-val) keyword)))
              (reduce concat))))
 
-(defn as-bindings
+(defn as-spec->bindings
+  "Converts as into bindings. Ex.: [{:as m} {:x 1}] => [m {:x 1}]"
   [binding-val [spec-key spec-val]]
   (when (= :as spec-key)
     [spec-val binding-val]))
 
-(defn or-bindings
+(defn or-spec->bindings
+  "Converts or into bindings. Ex.: [{:or {:x 0}} {:x 1}] => [x (or x 0)].
+
+  Note that this binding will fail if x was not previously destructured."
   [_ [spec-key spec-val]]
   (when (= :or spec-key)
     (->> spec-val
          (map (juxt first (partial apply list 'or)))
          (reduce concat))))
 
-(defn symbol-bindings
+(defn symbol-spec->bindings
+  "Converts symbols into bindings. Ex.: [{my-x :x} {:x 1}] => [my-x 1]"
   [binding-val [spec-key spec-val]]
   (when (symbol? spec-key)
     [spec-key (get binding-val (keyword spec-val))]))
@@ -27,9 +33,9 @@
 (defn bindings
   [[binding-spec binding-val]]
   (->> binding-spec
-       (map (some-fn (partial keys-bindings binding-val)
-                     (partial as-bindings binding-val)
-                     (partial or-bindings binding-val)
-                     (partial symbol-bindings binding-val)))
+       (map (some-fn (partial keys-spec->bindings binding-val)
+                     (partial as-spec->bindings binding-val)
+                     (partial or-spec->bindings binding-val)
+                     (partial symbol-spec->bindings binding-val)))
        (reduce concat)
        vec))

--- a/src/main/pedromanoel/playground/macros/destructuring/maps.clj
+++ b/src/main/pedromanoel/playground/macros/destructuring/maps.clj
@@ -1,7 +1,7 @@
 (ns pedromanoel.playground.macros.destructuring.maps)
 
 (defn keys-spec->bindings
-  "Converts keys into bindings. Ex.: [{:keys [x]} {:x 1}] => [x 1]"
+  "Converts :keys into bindings. Ex.: [{:keys [x]} {:x 1}] => [x 1]"
   [binding-val [spec-key spec-val]]
   (when (= :keys spec-key)
     (->> spec-val
@@ -9,13 +9,13 @@
              (reduce concat))))
 
 (defn as-spec->bindings
-  "Converts as into bindings. Ex.: [{:as m} {:x 1}] => [m {:x 1}]"
+  "Converts :as into bindings. Ex.: [{:as m} {:x 1}] => [m {:x 1}]"
   [binding-val [spec-key spec-val]]
   (when (= :as spec-key)
     [spec-val binding-val]))
 
 (defn or-spec->bindings
-  "Converts or into bindings. Ex.: [{:or {:x 0}} {:x 1}] => [x (or x 0)].
+  "Converts :or into bindings. Ex.: [{:or {:x 0}} {:x 1}] => [x (or x 0)].
 
   Note that this binding will fail if x was not previously destructured."
   [_ [spec-key spec-val]]

--- a/src/main/pedromanoel/playground/macros/destructuring/maps.clj
+++ b/src/main/pedromanoel/playground/macros/destructuring/maps.clj
@@ -23,4 +23,5 @@
 
                 :else
                 binding-spec)))
-       (reduce concat)))
+       (reduce concat)
+       vec))

--- a/src/main/pedromanoel/playground/macros/destructuring/maps.clj
+++ b/src/main/pedromanoel/playground/macros/destructuring/maps.clj
@@ -1,25 +1,41 @@
 (ns pedromanoel.playground.macros.destructuring.maps)
 
+(defn keys-bindings
+  [[_ spec-val] binding-val]
+  (->> spec-val
+       (map (juxt identity (comp (partial get binding-val) keyword)))
+       (reduce concat)))
+
+(defn as-bindings
+  [[_ spec-val] binding-val]
+  [spec-val binding-val])
+
+(defn or-bindings
+  [[_ spec-val]]
+  (->> spec-val
+       (map (juxt first (partial apply list 'or)))
+       (reduce concat)))
+
+(defn symbol-bindings
+  [[spec-key spec-val] binding-val]
+  [spec-key (->> spec-val keyword (get binding-val))])
+
 (defn bindings
   [[binding-spec binding-val]]
   (->> binding-spec
        (map (fn [[spec-key spec-val :as binding-spec]]
               (cond
                 (= :keys spec-key)
-                (->> spec-val
-                     (map (juxt identity (comp (partial get binding-val) keyword)))
-                     (reduce concat))
+                (keys-bindings binding-spec binding-val)
 
                 (= :as spec-key)
-                [spec-val binding-val]
+                (as-bindings binding-spec binding-val)
 
                 (= :or spec-key)
-                (->> spec-val
-                     (map (juxt first (partial apply list 'or)))
-                     (reduce concat))
+                (or-bindings binding-spec)
 
                 (symbol? spec-key)
-                [spec-key (->> spec-val keyword (get binding-val))]
+                (symbol-bindings binding-spec binding-val)
 
                 :else
                 binding-spec)))

--- a/src/main/pedromanoel/playground/macros/destructuring/maps.clj
+++ b/src/main/pedromanoel/playground/macros/destructuring/maps.clj
@@ -1,0 +1,26 @@
+(ns pedromanoel.playground.macros.destructuring.maps)
+
+(defn bindings
+  [[binding-spec binding-val]]
+  (->> binding-spec
+       (map (fn [[spec-key spec-val :as binding-spec]]
+              (cond
+                (= :keys spec-key)
+                (->> spec-val
+                     (map (juxt identity (comp (partial get binding-val) keyword)))
+                     (reduce concat))
+
+                (= :as spec-key)
+                [spec-val binding-val]
+
+                (= :or spec-key)
+                (->> spec-val
+                     (map (juxt first (partial apply list 'or)))
+                     (reduce concat))
+
+                (symbol? spec-key)
+                [spec-key (->> spec-val keyword (get binding-val))]
+
+                :else
+                binding-spec)))
+       (reduce concat)))

--- a/src/test/pedromanoel/playground/destructuring.clj
+++ b/src/test/pedromanoel/playground/destructuring.clj
@@ -51,8 +51,3 @@
     (testing "fn"
       (is (= "a value"
              ((fn [a-symbol] a-symbol) "a value"))))))
-
-(defmacro as-map [& vars]
-  (->> vars
-       (map (juxt keyword identity))
-       (into {})))

--- a/src/test/pedromanoel/playground/macros/destructuring/maps_test.clj
+++ b/src/test/pedromanoel/playground/macros/destructuring/maps_test.clj
@@ -39,6 +39,7 @@
                                      x     :x
                                      y     :y
                                      :or {x 0 y 0 z 0}} {:x 1 :z 2}])]
+      (is (vector? expanded))
       (is (match? '[x 1 y nil z 2
                     z 2
                     my-map {:x 1 :z 2}

--- a/src/test/pedromanoel/playground/macros/destructuring/maps_test.clj
+++ b/src/test/pedromanoel/playground/macros/destructuring/maps_test.clj
@@ -1,0 +1,47 @@
+(ns pedromanoel.playground.macros.destructuring.maps-test
+  (:require [clojure.test :refer :all]
+            [matcher-combinators.test :refer [match?]]
+            [pedromanoel.playground.macros.destructuring.maps :as maps]))
+
+(deftest keys-bindings-test
+  (testing "it returns a binding vector for :keys"
+    (let [expanded (maps/bindings '[{:keys [x y z]} {:x 1 :z 2}])]
+      (is (match? '[x 1 y nil z 2]
+                  expanded)))))
+
+(deftest symbols-bindings-test
+  (testing "it returns a binding vector with symbols and values"
+    (let [expanded (maps/bindings '[{my-x :x} {:x 1 :z 2}])]
+      (is (match? '[my-x 1]
+                  expanded)))))
+
+(deftest as-binding-test
+  (testing "it returns a binding vector for :as"
+    (let [expanded (maps/bindings '[{:as my-map} {:x 1 :z 2}])]
+      (is (match? '[my-map {:x 1 :z 2}]
+                  expanded)))))
+
+(deftest or-binding-test
+  (testing "it returns a binding vector for :or"
+    (let [expanded (maps/bindings '[{:or {x 0 y 0 z 0}} {:x 1 :z 2}])]
+      (is (match? '[x (or x 0) y (or y 0) z (or z 0)]
+                  expanded)))))
+
+(deftest bindings-test
+  (testing "it returns empty vector when binding-spec is empty"
+    (is (match? []
+                (maps/bindings '[{} {:x 1}]))))
+
+  (testing "it combines different types of bindings"
+    (let [expanded (maps/bindings '[{:keys [x y z]
+                                     z     :z
+                                     :as   my-map
+                                     x     :x
+                                     y     :y
+                                     :or {x 0 y 0 z 0}} {:x 1 :z 2}])]
+      (is (match? '[x 1 y nil z 2
+                    z 2
+                    my-map {:x 1 :z 2}
+                    x 1 y nil
+                    x (or x 0) y (or y 0) z (or z 0)]
+                  expanded)))))

--- a/src/test/pedromanoel/playground/macros/destructuring_test.clj
+++ b/src/test/pedromanoel/playground/macros/destructuring_test.clj
@@ -1,3 +1,0 @@
-(ns pedromanoel.playground.macros.destructuring-test
-  (:require [clojure.test :refer :all]
-            [pedromanoel.playground.macros.destructuring :as destructuring]))

--- a/src/test/pedromanoel/playground/macros/destructuring_test.clj
+++ b/src/test/pedromanoel/playground/macros/destructuring_test.clj
@@ -1,0 +1,17 @@
+(ns pedromanoel.playground.macros.destructuring-test
+  (:require [clojure.test :refer :all]
+            [matcher-combinators.test :refer [match?]]
+            [pedromanoel.playground.macros.destructuring :as destructuring]))
+
+(deftest my-let-map-test
+  (testing "it "
+    (is (match? {:x 1 :y 0 :z 2 :my-map {:x 1 :z 2}}
+                (destructuring/my-let [{:keys [x]
+                                        y     :y
+                                        z     :z
+                                        :as   my-map
+                                        :or   {y 0}} {:x 1 :z 2}]
+                  {:x      x
+                   :y      y
+                   :z      z
+                   :my-map my-map})))))

--- a/src/test/pedromanoel/playground/macros/destructuring_test.clj
+++ b/src/test/pedromanoel/playground/macros/destructuring_test.clj
@@ -1,0 +1,3 @@
+(ns pedromanoel.playground.macros.destructuring-test
+  (:require [clojure.test :refer :all]
+            [pedromanoel.playground.macros.destructuring :as destructuring]))

--- a/src/test/pedromanoel/playground/macros/destructuring_test.clj
+++ b/src/test/pedromanoel/playground/macros/destructuring_test.clj
@@ -1,17 +1,21 @@
 (ns pedromanoel.playground.macros.destructuring-test
   (:require [clojure.test :refer :all]
             [matcher-combinators.test :refer [match?]]
-            [pedromanoel.playground.macros.destructuring :as destructuring]))
+            [pedromanoel.playground.macros.destructuring :refer [my-let]]))
 
 (deftest my-let-map-test
-  (testing "it "
-    (is (match? {:x 1 :y 0 :z 2 :my-map {:x 1 :z 2}}
-                (destructuring/my-let [{:keys [x]
-                                        y     :y
-                                        z     :z
-                                        :as   my-map
-                                        :or   {y 0}} {:x 1 :z 2}]
-                  {:x      x
-                   :y      y
-                   :z      z
-                   :my-map my-map})))))
+  (testing "it destructures maps correctly"
+    (is (match? {:name "Pedro"
+                 :age :unknown
+                 :my-name "Pedro"
+                 :person {:name "Pedro"}}
+                (my-let [{:keys   [name age]
+                          my-name :name
+                          :as     person
+                          :or     {name :unknown
+                                   age  :unknown}}
+                         {:name "Pedro"}]
+                  {:name name
+                   :age age
+                   :my-name my-name
+                   :person person})))))


### PR DESCRIPTION
# What

Implement map destructuring on a `my-let` macro:

```
(my-let [{:keys   [name age]
          my-name :name
          :as     person
          :or     {name :unknown
                   age  :unknown}}
         {:name "Pedro"}]
  {:name name
   :age age
   :my-name my-name
   :person person})
```

# Why

I wanted to grok how map destructuring works.

The way I understand it now is that the left side of a binding is a specification on how to bind to values.

This PR implements only map destructuring, where the spec might contain:

* `:keys` - bind to the specified keys with the same name
* `symbol` - bind symbol on the left with the keyword on the right
* `:as` - bind whole value to specified symbol
* `:or` - provide alternative values to previously specified symbols

# How

I created a `destructuring/my-let` macro that passes the binding vector as data to auxiliary functions inside `destructuring.map` namespace.